### PR TITLE
feat: parse color from string

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ CSS strings can be generated from a color using the `.string()` method
 color.hsl().string(); // 'hsl(320, 50%, 100%)'
 ```
 
+Also, you can generate Color objects from CSS strings
+```typescript
+Color.string("#FDA").hex() // #ffddaa
+Color.string('hsl(180, 10%, 20%)').hsl().string() // hsl(180, 10%, 20%)
+Color.string('hsla(180, 10%, 20%, 0.2)').hsla().string() // hsla(180, 10%, 20%, 0.2)
+Color.string('cmyk(100%, 0%, 0%, 0%)').cmyk().string() // cmyk(100%, 0%, 0%, 0%)
+Color.string('hwb(12 50% 0%)').hwb().string() // hwb(12 50% 0%)
+```
+
 ### Luminosity
 
 The WCAG luminosity of the color. 0 is black, 1 is white.

--- a/README.md
+++ b/README.md
@@ -64,12 +64,13 @@ color.hsl().string(); // 'hsl(320, 50%, 100%)'
 ```
 
 Also, you can generate Color objects from CSS strings
+
 ```typescript
-Color.string("#FDA").hex() // #ffddaa
-Color.string('hsl(180, 10%, 20%)').hsl().string() // hsl(180, 10%, 20%)
-Color.string('hsla(180, 10%, 20%, 0.2)').hsla().string() // hsla(180, 10%, 20%, 0.2)
-Color.string('cmyk(100%, 0%, 0%, 0%)').cmyk().string() // cmyk(100%, 0%, 0%, 0%)
-Color.string('hwb(12 50% 0%)').hwb().string() // hwb(12 50% 0%)
+Color.string("#FDA").hex(); // #ffddaa
+Color.string("hsl(180, 10%, 20%)").hsl().string(); // hsl(180, 10%, 20%)
+Color.string("hsla(180, 10%, 20%, 0.2)").hsla().string(); // hsla(180, 10%, 20%, 0.2)
+Color.string("cmyk(100%, 0%, 0%, 0%)").cmyk().string(); // cmyk(100%, 0%, 0%, 0%)
+Color.string("hwb(12 50% 0%)").hwb().string(); // hwb(12 50% 0%)
 ```
 
 ### Luminosity

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,9 @@
+{
+  "version": "2",
+  "remote": {
+    "https://deno.land/std@0.162.0/fmt/colors.ts": "9e36a716611dcd2e4865adea9c4bec916b5c60caad4cdcdc630d4974e6bb8bd4",
+    "https://deno.land/std@0.162.0/testing/_diff.ts": "a23e7fc2b4d8daa3e158fa06856bedf5334ce2a2831e8bf9e509717f455adb2c",
+    "https://deno.land/std@0.162.0/testing/_format.ts": "cd11136e1797791045e639e9f0f4640d5b4166148796cad37e6ef75f7d7f3832",
+    "https://deno.land/std@0.162.0/testing/asserts.ts": "1e340c589853e82e0807629ba31a43c84ebdcdeca910c4a9705715dfdb0f5ce8"
+  }
+}

--- a/mod.ts
+++ b/mod.ts
@@ -25,20 +25,20 @@ export class Color {
   static string(input: string) {
     const [, threeDigitHex] = input.match(/^#([0-9a-f]{3})$/i) ?? [];
     if (threeDigitHex) {
-      return [
+      return new Color([
         Number.parseInt(threeDigitHex.charAt(0), 16) * 0x11,
         Number.parseInt(threeDigitHex.charAt(1), 16) * 0x11,
         Number.parseInt(threeDigitHex.charAt(2), 16) * 0x11,
-      ];
+      ], "rgb");
     }
 
     const [, sixDigitHex] = input.match(/^#([0-9a-f]{6})$/i) ?? [];
     if (sixDigitHex) {
-      return [
+      return new Color([
         Number.parseInt(sixDigitHex.substring(0, 2), 16),
         Number.parseInt(sixDigitHex.substring(2, 4), 16),
         Number.parseInt(sixDigitHex.substring(4, 6), 16),
-      ];
+      ], "rgb");
     }
 
     const [, cmyk, ...channelsCMYK] = input.match(

--- a/mod.ts
+++ b/mod.ts
@@ -22,6 +22,47 @@ export class Color {
 
   // Constructors
 
+  static string(input: string) {
+    const [, threeDigitHex] = input.match(/^#([0-9a-f]{3})$/i) ?? [];
+    if (threeDigitHex) {
+      return [
+        Number.parseInt(threeDigitHex.charAt(0), 16) * 0x11,
+        Number.parseInt(threeDigitHex.charAt(1), 16) * 0x11,
+        Number.parseInt(threeDigitHex.charAt(2), 16) * 0x11,
+      ];
+    }
+
+    const [, sixDigitHex] = input.match(/^#([0-9a-f]{6})$/i) ?? [];
+    if (sixDigitHex) {
+      return [
+        Number.parseInt(sixDigitHex.substring(0, 2), 16),
+        Number.parseInt(sixDigitHex.substring(2, 4), 16),
+        Number.parseInt(sixDigitHex.substring(4, 6), 16),
+      ];
+    }
+
+    const [, cmyk, ...channelsCMYK] = input.match(
+      /^(cmyk)\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(,\s*(\d+)\s*)?\)$/i,
+    ) ?? [];
+    if (cmyk === "cmyk" && channelsCMYK.length === 4) {
+      return new Color(channelsCMYK.map((c) => Number.parseInt(c)), cmyk);
+    }
+
+    const [, type, ...channels] = input.match(
+      /^(rgba?|hsla?|hsva?|hwba?)\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,?\s*((0|1)(\.\d*)?)\s*\)$/i,
+    ) ?? [];
+
+    if (type && channels.length >= 3) {
+      return new Color(
+        channels.slice(0, 3).map((c) => Number.parseInt(c)),
+        type as colorTypes,
+        Number(channels[3]),
+      );
+    }
+
+    throw new Error(`Color ${input} is not a valid color`);
+  }
+
   /**
    * Creates a color with a red, green, and blue value
    */
@@ -366,7 +407,7 @@ export class Color {
     const max = Math.max(r, g, b),
       min = Math.min(r, g, b),
       d = max - min,
-      s = (max === 0 ? 0 : d / max),
+      s = max === 0 ? 0 : d / max,
       v = max / 255;
 
     let h = 0;

--- a/mod.ts
+++ b/mod.ts
@@ -48,8 +48,8 @@ export class Color {
       return new Color(channelsCMYK.map((c) => Number.parseInt(c)), cmyk);
     }
 
-    const [, type, ...channels] = input.match(
-      /^(rgba?|hsla?|hsva?|hwba?)\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,?\s*((0|1)(\.\d*)?)\s*\)$/i,
+    const [, type, ...channels] = input.replace(/%/g, "").match(
+      /^(rgba?|hsla?|hsva?|hwba?)\s*\(\s*(\d+)\s*,\s*(\d+)?\s*,\s*(\d+)?\s*,?\s*((0|1)(\.\d*)?)\s*\)$/i,
     ) ?? [];
 
     if (type && channels.length >= 3) {

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -129,3 +129,27 @@ Deno.test("README Color space conversions", () => {
   assertEquals(color.setBlack(255).string(), "rgb(0, 0, 0)");
   assertEquals(color.setHue(200).string(), "rgb(0, 170, 255)");
 });
+
+Deno.test("README CSS Strings", () => {
+  assertEquals(Color.string("#FDA").hex(), "#ffddaa");
+  assertEquals(
+    Color.string("rgba(150 120 80 / 0.4)").rgba().string(),
+    "rgba(150, 120, 80, 0.4)",
+  );
+  assertEquals(
+    Color.string("hsl(180, 10%, 20%)").hsl().string(),
+    "hsl(180, 10%, 20%)",
+  );
+  assertEquals(
+    Color.string("hsla(180, 10%, 20%, 0.2)").hsla().string(),
+    "hsla(180, 10%, 20, 0.2)",
+  );
+  assertEquals(
+    Color.string("cmyk(100%, 0%, 0%, 0%)").cmyk().string(),
+    "cmyk(100%, 0%, 0%, 0%)",
+  );
+  assertEquals(
+    Color.string("hwba(0.5turn 10% 0% / .5)").hwba().string(),
+    "hwba(180, 10%, 0%, 0.5)",
+  );
+});


### PR DESCRIPTION
This PR adds a `Color.string` function to instantiate color object from a string. Allowed strings are:

```
rgb(0, 0, 0)
hsl(180, 10%, 20%)
hsv(180, 50%, 20%)
#fd1
#fd11df
```

If nothing is matched, an error is thrown